### PR TITLE
Add screen for adding locations

### DIFF
--- a/internal/fd/app.go
+++ b/internal/fd/app.go
@@ -9,10 +9,10 @@ import (
 
 type App struct {
 	viewService     ViewService
-	locationService LocationService
+	locationService *LocationService
 }
 
-func NewApp(viewService ViewService, locationService LocationService) *App {
+func NewApp(viewService ViewService, locationService *LocationService) *App {
 	return &App{viewService, locationService}
 }
 
@@ -42,7 +42,7 @@ func (this *App) AddLocation(key string) {
 }
 
 func (this *App) ViewUserInterface() {
-	program := tea.NewProgram(this.viewService)
+	program := tea.NewProgram(this.viewService, tea.WithAltScreen())
 	model, err := program.Run()
 	if err != nil {
 		this.handleError("Error creating user interface:", err)

--- a/internal/fd/location.go
+++ b/internal/fd/location.go
@@ -13,7 +13,7 @@ type LocationService struct {
 	selectFile   string
 }
 
-func NewLocationService() LocationService {
+func NewLocationService() *LocationService {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		fmt.Println("Error getting user home directory:", err)
@@ -23,10 +23,10 @@ func NewLocationService() LocationService {
 	appDir := "/.fd-app"
 	locationFile := homeDir + appDir + "/locations"
 	selectFile := homeDir + appDir + "/select"
-	return LocationService{locationFile, selectFile}
+	return &LocationService{locationFile, selectFile}
 }
 
-func (this LocationService) CurrentLocation() (string, error) {
+func (this *LocationService) CurrentLocation() (string, error) {
 	location, err := os.Getwd()
 	if err != nil {
 		return location, err
@@ -57,7 +57,7 @@ func (this *LocationService) ReadSavedLocations() (map[string]string, error) {
 	return locations, nil
 }
 
-func (this LocationService) SaveSelectedLocation(selected string) error {
+func (this *LocationService) SaveSelectedLocation(selected string) error {
 	err := os.WriteFile(this.selectFile, []byte(selected), 0666)
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func (this LocationService) SaveSelectedLocation(selected string) error {
 	return nil
 }
 
-func (this LocationService) SaveLocations(locations map[string]string) error {
+func (this *LocationService) SaveLocations(locations map[string]string) error {
 	var builder strings.Builder
 	keys := []string{}
 	for k := range locations {

--- a/internal/fd/view.go
+++ b/internal/fd/view.go
@@ -10,65 +10,32 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-const (
-	ModeSelect = "select"
-	ModeDelete = "delete"
-)
-
-type ViewService struct {
-	locationService LocationService
-	locations       map[string]string
-	selected        string
-	helpText        string
-	mode            string
+type Screen interface {
+	Init() tea.Cmd
+	Update(msg tea.Msg) (tea.Model, tea.Cmd)
+	View() string
 }
 
-func NewViewService(locationService LocationService) ViewService {
-	locations, err := locationService.ReadSavedLocations()
-	if err != nil {
-		fmt.Println("Error initializing view service:", err)
-		os.Exit(1)
-	}
+type SelectScreen struct {
+	locations map[string]string
+	helpText  string
+}
 
-	return ViewService{
-		locationService: locationService,
-		locations:       locations,
-		helpText:        "Select a location to jump to.",
-		mode:            ModeSelect,
+func NewSelectScreen(locations map[string]string) SelectScreen {
+	return SelectScreen{
+		locations: locations,
+		helpText:  "Select a location to jump to.",
 	}
 }
 
-func (this ViewService) Init() tea.Cmd {
+func (this SelectScreen) Init() tea.Cmd {
 	return nil
 }
 
-func (this ViewService) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (this SelectScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
-	case errMsg:
-		this.helpText = msg.err.Error()
-		return this, nil
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "esc", "ctrl+c":
-			currentDirectory, err := this.locationService.CurrentLocation()
-			if err != nil {
-				return this, tea.Quit
-			}
-
-			this.selected = currentDirectory
-			return this, this.saveSelectedAndQuit()
-
-		case " ":
-			if this.mode == ModeSelect {
-				this.mode = ModeDelete
-				this.helpText = "Delete a location binding."
-				return this, nil
-			}
-
-			this.helpText = "Select a location to jump to."
-			this.mode = ModeSelect
-			return this, nil
-
 		default:
 			key := msg.String()
 			path, ok := this.locations[key]
@@ -77,65 +44,16 @@ func (this ViewService) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return this, nil
 			}
 
-			if this.mode == ModeDelete {
-				delete(this.locations, key)
-				this.helpText = fmt.Sprintf("Deleted location from %s.", key)
-				return this, this.saveLocations()
-			}
-
-			this.selected = path
-			return this, this.saveSelectedAndQuit()
+			return this, SaveSelectedCmd(path)
 		}
 	}
 
 	return this, nil
 }
 
-func (this ViewService) View() string {
-	if this.mode == ModeDelete {
-		return this.deleteView()
-	}
-
-	return this.selectView()
-}
-
-func dirName(path string) string {
-	parts := strings.Split(path, "/")
-	name := parts[len(parts)-1]
-	return name
-}
-
-var (
-	success = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
-	danger  = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
-)
-
-func (this ViewService) deleteView() string {
+func (this SelectScreen) View() string {
 	var builder strings.Builder
-	builder.WriteString("Fav Dirs\n\n")
-
-	keys := []string{}
-	for k := range this.locations {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, key := range keys {
-		path := this.locations[key]
-		dir := dirName(path)
-		bind := danger.Render(key)
-		prefix := danger.Render("!!!")
-		builder.WriteString(fmt.Sprintf("%s [%s] %s\n", prefix, bind, dir))
-	}
-
-	space := success.Render("space")
-	esc := danger.Render("esc")
-	builder.WriteString(fmt.Sprintf("\n[help] %s [%s] %s [%s] exit\n", this.helpText, space, ModeSelect, esc))
-	return builder.String()
-}
-
-func (this ViewService) selectView() string {
-	var builder strings.Builder
-	builder.WriteString("Fav Dirs\n\n")
+	builder.WriteString(fmt.Sprintf("\n[help] %s\n\n", this.helpText))
 
 	keys := []string{}
 	for k := range this.locations {
@@ -150,29 +68,238 @@ func (this ViewService) selectView() string {
 		builder.WriteString(fmt.Sprintf("%s [%s] %s\n", prefix, bind, dir))
 	}
 
-	space := danger.Render("space")
-	esc := danger.Render("esc")
-	builder.WriteString(fmt.Sprintf("\n[help] %s [%s] %s [%s] exit\n", this.helpText, space, ModeDelete, esc))
+	builder.WriteString(fmt.Sprintf("\n[ctrl+a] Add [ctrl+d] Delete\n"))
 	return builder.String()
 }
 
-type saveMsg struct{}
-type errMsg struct {
-	err error
+type DeleteScreen struct {
+	locations map[string]string
+	helpText  string
 }
 
-func (this ViewService) saveLocations() tea.Cmd {
-	return func() tea.Msg {
-		err := this.locationService.SaveLocations(this.locations)
-		if err != nil {
-			return errMsg{err}
-		}
-
-		return saveMsg{}
+func NewDeleteScreen(locations map[string]string) DeleteScreen {
+	return DeleteScreen{
+		locations: locations,
+		helpText:  "Delete a location binding.",
 	}
 }
 
-func (this ViewService) saveSelectedAndQuit() tea.Cmd {
-	this.locationService.SaveSelectedLocation(this.selected)
-	return tea.Quit
+func (this DeleteScreen) Init() tea.Cmd {
+	return nil
+}
+
+func (this DeleteScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		key := msg.String()
+		_, ok := this.locations[key]
+		if !ok {
+			this.helpText = fmt.Sprintf("No location bound to %s.", key)
+			return this, nil
+		}
+
+		delete(this.locations, key)
+		this.helpText = fmt.Sprintf("Deleted location from %s.", key)
+		return this, SaveLocationsCmd(this.locations)
+	}
+
+	return this, nil
+}
+
+func (this DeleteScreen) View() string {
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("\n[help] %s\n\n", this.helpText))
+
+	keys := []string{}
+	for k := range this.locations {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		path := this.locations[key]
+		dir := dirName(path)
+		bind := danger.Render(key)
+		prefix := danger.Render("!!!")
+		builder.WriteString(fmt.Sprintf("%s [%s] %s\n", prefix, bind, dir))
+	}
+
+	builder.WriteString(fmt.Sprintf("\n[ctrl+s] Select [ctrl+a] Add\n"))
+	return builder.String()
+}
+
+type AddScreen struct {
+	current   string
+	locations map[string]string
+	helpText  string
+}
+
+func NewAddScreen(current string, locations map[string]string) AddScreen {
+	return AddScreen{
+		locations: locations,
+		current:   current,
+		helpText:  "Add current location by pressing a key.",
+	}
+}
+
+func (this AddScreen) Init() tea.Cmd {
+	return nil
+}
+
+func (this AddScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		default:
+			key := msg.String()
+			_, ok := this.locations[key]
+			if ok {
+				this.helpText = fmt.Sprintf("Key %s is already bound to a location.", key)
+				return this, nil
+			}
+
+			this.locations[key] = this.current
+			this.helpText = fmt.Sprintf("Location added to %s.", key)
+			return this, SaveLocationsCmd(this.locations)
+		}
+	}
+
+	return this, nil
+}
+
+func (this AddScreen) View() string {
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("\n[help] %s\n\n", this.helpText))
+
+	keys := []string{}
+	for k := range this.locations {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		path := this.locations[key]
+		dir := dirName(path)
+		bind := success.Render(key)
+		prefix := success.Render("+++")
+		builder.WriteString(fmt.Sprintf("%s [%s] %s\n", prefix, bind, dir))
+	}
+
+	builder.WriteString(fmt.Sprintf("\n[ctrl+s] Select [ctrl+d] Delete\n"))
+	return builder.String()
+}
+
+type ViewService struct {
+	locationService *LocationService
+	locations       map[string]string
+	current         string
+	selected        string
+	screen          Screen
+}
+
+func NewViewService(locationService *LocationService) ViewService {
+	locations, err := locationService.ReadSavedLocations()
+	if err != nil {
+		fmt.Println("Error initializing view service:", err)
+		os.Exit(1)
+	}
+
+	currentLocation, err := locationService.CurrentLocation()
+	if err != nil {
+		fmt.Println("Error initializing view service:", err)
+		os.Exit(1)
+	}
+
+	return ViewService{
+		locationService: locationService,
+		locations:       locations,
+		current:         currentLocation,
+		screen:          NewSelectScreen(locations),
+	}
+}
+
+func (this ViewService) Init() tea.Cmd {
+	return nil
+}
+
+type SaveLocationsMsg struct {
+	locations map[string]string
+}
+
+func SaveLocationsCmd(locations map[string]string) tea.Cmd {
+	return func() tea.Msg {
+		return SaveLocationsMsg{locations}
+	}
+}
+
+type SaveSelectedMsg struct {
+	selected string
+}
+
+func SaveSelectedCmd(selected string) tea.Cmd {
+	return func() tea.Msg {
+		return SaveSelectedMsg{selected}
+	}
+}
+
+type ExitAppMsg struct {
+	selected string
+}
+
+func ExitAppCmd(selected string) tea.Cmd {
+	return func() tea.Msg {
+		return ExitAppMsg{selected}
+	}
+}
+
+func (this ViewService) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case SaveSelectedMsg:
+		this.selected = msg.selected
+		this.locationService.SaveSelectedLocation(msg.selected)
+		return this, tea.Quit
+
+	case SaveLocationsMsg:
+		this.locations = msg.locations
+		this.locationService.SaveLocations(msg.locations)
+		return this, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc", "ctrl+c":
+			return this, SaveSelectedCmd(this.current)
+
+		case "ctrl+d":
+			this.screen = NewDeleteScreen(this.locations)
+			return this, nil
+
+		case "ctrl+a":
+			this.screen = NewAddScreen(this.current, this.locations)
+			return this, nil
+
+		case "ctrl+s":
+			this.screen = NewSelectScreen(this.locations)
+			return this, nil
+
+		default:
+			screen, cmd := this.screen.Update(msg)
+			this.screen = screen
+			return this, cmd
+		}
+	}
+
+	return this, nil
+}
+
+func (this ViewService) View() string {
+	return this.screen.View()
+}
+
+var (
+	success = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	danger  = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+)
+
+func dirName(path string) string {
+	parts := strings.Split(path, "/")
+	name := parts[len(parts)-1]
+	return name
 }

--- a/internal/util/function_template
+++ b/internal/util/function_template
@@ -1,5 +1,5 @@
 {{.StartComment}}
-function {{.Alias}}() {
+{{.Alias}}() {
     {{.ExecutablePath}} "$@"
     output=$(< {{.SelectPath}})
     cd $output


### PR DESCRIPTION
- Refactors views into different screen structs to manage multiple views easier
- Adds a new screen for adding a keybind for the current location
- Runs user interface in an alternate screen to reduce terminal pollution